### PR TITLE
Set "sane" default rotation settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 *.cfg
 *.sublime*
 /sfml
+
+# default Code::Blocks output folder
+/SpeedBlocks

--- a/optionSet.cpp
+++ b/optionSet.cpp
@@ -92,8 +92,15 @@ short optionSet::loadOptions() {
 		frameDelay = sf::milliseconds(10);
 		inputDelay = sf::milliseconds(5);
 
-		for (int x=0; x<7; x++)
-			piecerotation[x] = 0;
+		piecerotation[0] = 3;
+		piecerotation[1] = 1;
+		piecerotation[2] = 3;
+		piecerotation[3] = 1;
+		piecerotation[4] = 1;
+		piecerotation[5] = 2;
+		piecerotation[6] = 0;
+
+
 
 		name="Player";
 		currentmode=-1;


### PR DESCRIPTION
These should be the default rotation settings in Cultris II.

The change is made as @zDEFz had issues getting the default C2 settings
back and erroneously setting the S and Z pieces to rotation state to 1
and 3 respectively. This led to needing two 180 spins to get the pieces
to teleport down "diagonally", as opposed to when the defaults are set
so that S is 3 and Z is 1, in which case only one 180 is needed.