### PR TITLE
Fix deprecation errors for visual studio

### DIFF
--- a/gamePlay.h
+++ b/gamePlay.h
@@ -1,6 +1,9 @@
 #ifndef GAMEPLAY_H
 #define GAMEPLAY_H
 
+//fixes deprecation problems
+#pragma warning(disable: 4996)
+
 #include <SFML/Graphics.hpp>
 #include <deque>
 #include "pieces.h"


### PR DESCRIPTION
simple but effective #pragma warning(disable: 4996)