### PR TITLE
Updated CMakeLists.txt for MinGW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,48 +2,32 @@ cmake_minimum_required(VERSION 3.5)
 
 project(SpeedBlocks)
 
-set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/Modules")
-
+set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules")
+set(CMAKE_VERBOSE_MAKEFILE ON)
 set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -Wall -Wextra -pedantic")
+set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "-Wall -Wextra -pedantic")
 
-set(SOURCE_FILES
-        EmptyResourcePath.cpp
-        EmptyResourcePath.h
-        gameField.cpp
-        gameField.h
-        gameFieldDrawer.cpp
-        gamePlay.cpp
-        gamePlay.h
-        gui.cpp
-        gui.h
-        main.cpp
-        MingwConvert.cpp
-        MingwConvert.h
-        network.cpp
-        network.h
-        optionSet.cpp
-        optionSet.h
-        packetcompress.cpp
-        packetcompress.h
-        pieces.cpp
-        pieces.h
-        randomizer.cpp
-        randomizer.h
-        ResourcePath.hpp
-        sounds.cpp
-        sounds.h
-        textures.cpp
-        textures.h)
+set(EXECUTABLE_NAME SpeedBlocks)
+file(GLOB SOURCE_FILES ${CMAKE_SOURCE_DIR}/*.cpp ${CMAKE_SOURCE_DIR}/*.h  ${CMAKE_SOURCE_DIR}/*.hpp)
+add_executable(${EXECUTABLE_NAME} ${SOURCE_FILES})
 
-add_executable(SpeedBlocks ${SOURCE_FILES})
+if (WIN32)
+    if (NOT BOOST_ROOT)
+        message(SEND_ERROR "BOOST_ROOT not set")
+    endif()
+endif()
 
 find_package(SFML 2 COMPONENTS audio network graphics window system REQUIRED)
-
 find_package(TGUI 0.7.3 REQUIRED)
 
-target_link_libraries(SpeedBlocks ${SFML_LIBRARIES} ${TGUI_LIBRARY})
+if (WIN32)
+    include_directories(${SFML_INCLUDE_DIR} ${TGUI_INCLUDE_DIR} ${BOOST_ROOT})
+endif()
+
+target_link_libraries(${EXECUTABLE_NAME} ${SFML_LIBRARIES} ${TGUI_LIBRARY})
 
 if (NOT ${CMAKE_SOURCE_DIR} MATCHES ${CMAKE_CURRENT_BINARY_DIR})
     file(COPY ${CMAKE_SOURCE_DIR}/media DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/MingwConvert.cpp
+++ b/MingwConvert.cpp
@@ -1,4 +1,5 @@
 #ifdef __MINGW32__
+#if __GNUC__ < 6 || (__GNUC__ == 6 && __GNUC_MINOR__ < 1)
 
 #include <boost/lexical_cast.hpp>
 #include "MingwConvert.h"
@@ -10,4 +11,5 @@ short stoi(std::string convert_str) {
 	return boost::lexical_cast<short>(convert_str);
 }
 
+#endif
 #endif

--- a/MingwConvert.h
+++ b/MingwConvert.h
@@ -1,9 +1,11 @@
 #ifndef _MINGWCONVERT_H
 #define _MINGWCONVERT_H
-#ifdef __MINGW32__
 
+#ifdef __MINGW32__
+#if __GNUC__ < 6 || (__GNUC__ == 6 && __GNUC_MINOR__ < 1)
 std::string to_string(int);
 short stoi(std::string);
-
 #endif
+#endif
+
 #endif


### PR DESCRIPTION
Got MinGW Makefiles generator for CMake to work with MinGW-w64 6.1.0. I added a Windows condition
```
if (WIN32)
    include_directories(${SFML_INCLUDE_DIR} ${TGUI_INCLUDE_DIR} ${BOOST_ROOT})
endif()
```
to allow the Boost directory to be specified. Would be great if someone could test on Linux to verify nothing has been broken.