### PR TITLE
Change combo counter to not reset until start of next combo

### DIFF
--- a/gamePlay.cpp
+++ b/gamePlay.cpp
@@ -353,7 +353,6 @@ void gamePlay::delayCheck() {
 			maxCombo=comboCount;
 
 		comboCount = 0;
-		comboText.setString(to_string(comboCount));
 		draw();
 	}
 


### PR DESCRIPTION
Not sure what happens in multiplayer. Maybe another fix is required.